### PR TITLE
Removing provides!

### DIFF
--- a/_data/modules.yml
+++ b/_data/modules.yml
@@ -21,7 +21,6 @@
 - code: ma1500
   name: Introduction to Probability Theory
   credits: 10
-  provides: ['ma1501', 'ma0261', 'ma2500']
   more-info: 1516-MA1500
 
 - code: ma1006
@@ -32,38 +31,32 @@
 - code: ma1003
   name: Computing for Mathematics
   credits: 20
-  provides: ['ma0276']
   more-info: 1516-MA1003
 
 - code: ma1300
   name: Mechanics I
   credits: 10
-  provides: ['ma0235', 'ma2300']
   more-info: 1516-MA1300
 
 - code: ma0111
   name: Elementary Number Theory I
   credits: 10
-  provides: ['ma0216']
   more-info: 1516-MA0111
 
 - code: ma1501
   name: Statistical Inference
   credits: 10
   requires: ['ma1500']
-  provides: ['ma2500', 'ma2501', 'ma3502', 'ma3504']
   more-info: 1516-MA1501
 
 - code: ma0221
   name: Analysis III
   credits: 10
-  provides: ['ma3005']
   more-info: 1516-MA0221
 
 - code: ma0212
   name: Linear Algebra
   credits: 10
-  provides: ['ma0322', 'ma3005']
   more-info: 1516-MA0212
 
 - code: ma2004
@@ -84,7 +77,6 @@
 - code: ma2003
   name: Complex Analysis
   credits: 10
-  provides: ['ma3000']
   more-info: 1516-MA2003
 
 - code: ma0216
@@ -96,20 +88,17 @@
 - code: ma0232
   name: Modelling with Differential Equations
   credits: 10
-  provides: ['ma3301']
   more-info: 1516-MA0232
 
 - code: ma0235
   name: Elementary Fluid Dynamics
   credits: 10
-  provides: ['ma0332']
   requires: ['ma1300', 'ma2301']
   more-info: 1516-MA0235
 
 - code: ma0261
   name: Operational Research
   credits: 20
-  provides: ['ma3602', 'ma3601']
   requires: ['ma1500']
   more-info: 1516-MA0261
 
@@ -128,7 +117,6 @@
 - code: ma2301
   name: Vector Calculus
   credits: 10
-  provides: ['ma0235', 'ma0332']
   more-info: 1516-MA2301
 
 - code: ma2700
@@ -149,7 +137,6 @@
 - code: ma2500
   name: Foundations of Probability and Statistics
   credits: 20
-  provides: ['ma2501', 'ma0367', 'ma3501', 'ma3503', 'ma3505']
   requires: ['ma1500', 'ma1501']
   more-info: 1516-MA2500
 

--- a/_includes/module_info.html
+++ b/_includes/module_info.html
@@ -1,7 +1,16 @@
 {% for m in site.data.modules %}
+  {% if m.requires contains code %}
+    {% if provides %}
+       {% assign provides = provides | append: " " | append: m.code %}
+    {% else %}
+       {% assign provides = m.code %}
+    {% endif %}
+  {% endif %}
+
   {% if m.code == code %}
     {% assign module = m %}
   {% endif %}
+
 {% endfor %}
 
 <h2>{{module.name}}</h2>
@@ -12,12 +21,15 @@
     <aside>Credits:<span class="credit">{{module.credits}}</span></aside>
 </div>
 
-{% if module.provides %}
+{% if provides %}
 <div class="provides">
-  {% for c in module.provides %}
+  {% assign provide_list = provides | split:" " %}
+  {% for c in provide_list %}
    <span class="{{c}}"></span>
   {% endfor %}
 </div>
+
+{% assign provides = false %}
 {% endif %}
 
 {% if module.requires %}

--- a/tests/module-schema.yml
+++ b/tests/module-schema.yml
@@ -17,12 +17,6 @@ sequence:
         type: str
         required: yes
         pattern: "/[0-9]{4}-[A-Z]{2}[0-9]{4}/"
-      "provides":
-        type: seq
-        required: no
-        sequence:
-          - type: str
-            pattern: "/[a-z]{2}[0-9]{4}/"
       "requires":
         type: seq
         required: no


### PR DESCRIPTION
The template code is now smart enough that we don't need to explicitly
include the modules that are provided for a particular module. Modules
now only need to specify which modules they depend on.

Provides has now been deleted from the database and the tests
