### PR TITLE
Removing redundant yaml frontmatter

### DIFF
--- a/cy/bsc.html
+++ b/cy/bsc.html
@@ -2,5 +2,4 @@
 layout: course
 short: bsc
 lang: cy
-title: BSc Mathematics
 ---

--- a/cy/mapps.html
+++ b/cy/mapps.html
@@ -2,5 +2,4 @@
 layout: course
 short: mapps
 lang: cy
-title: Mathematics and its Applications
 ---

--- a/cy/mmath.html
+++ b/cy/mmath.html
@@ -2,5 +2,4 @@
 layout: course
 short: mmath
 lang: cy
-title: MMath Mathematics
 ---

--- a/cy/mors.html
+++ b/cy/mors.html
@@ -2,5 +2,4 @@
 layout: course
 short: mors
 lang: cy
-title: Mathematics, Operational Research and Statistics
 ---

--- a/en/bsc.html
+++ b/en/bsc.html
@@ -2,5 +2,4 @@
 layout: course
 short: bsc
 lang: en
-title: BSc Mathematics
 ---

--- a/en/mapps.html
+++ b/en/mapps.html
@@ -2,5 +2,4 @@
 layout: course
 short: mapps
 lang: en
-title: Mathematics and its Applications
 ---

--- a/en/mmath.html
+++ b/en/mmath.html
@@ -2,5 +2,4 @@
 layout: course
 short: mmath
 lang: en
-title: MMath Mathematics
 ---

--- a/en/mors.html
+++ b/en/mors.html
@@ -2,5 +2,4 @@
 layout: course
 short: mors
 lang: en
-title: Mathematics, Operational Research and Statistics
 ---


### PR DESCRIPTION
In each of the courses there is a field

`name: <name-of-course>`

which is no longer used, so this removes them
