### PR TITLE
Adding #ref for pre-requisits.

### DIFF
--- a/_includes/module_info.html
+++ b/_includes/module_info.html
@@ -47,7 +47,7 @@
         {% assign required = m %}
       {% endif %}
     {% endfor %}
-    <li class="{{c}}">{{required.name}}</li>
+    <li class="{{c}}"><a href="#{{required.code}}">{{required.name}}</a></li>
   {% endfor %}
 </ul>
 {% endif %}


### PR DESCRIPTION
![animation](https://cloud.githubusercontent.com/assets/8998661/14769913/777bc91e-0a5b-11e6-8f8f-dee996d56bc2.gif)

As you can see in the above gif, the pre-requsit modules are now clickable links which take you to that module. fix #25 
