### PR TITLE
Fixing more-info link bug

### DIFF
--- a/docs/Implementation_Docs/module-html.rst
+++ b/docs/Implementation_Docs/module-html.rst
@@ -88,7 +88,7 @@ Next we add a link to where the user can find more information about the content
 of the module as well as how many credits it is worth::
 
     <div class="group">
-        <a href="{{site.data.settings.info}}/{{module.more-info}}.html" target="_blank">{{lang.more-info}}</a>
+        <a href="{{site.data.settings.info}}/{{module.code | upcase}}.html" target="_blank">{{lang.more-info}}</a>
         <aside>{{lang.credits}}:<span class="credit">{{module.credits}}</span></aside>
     </div>
 

--- a/docs/Implementation_Docs/module-selection.rst
+++ b/docs/Implementation_Docs/module-selection.rst
@@ -98,6 +98,24 @@ is as simple as::
             updateTotals(creditTotals);
     });
 
+Since the above defined the entire module :code:`div` element to be clickable
+that when the user clicks on the :code:`more-info` link it fools our code into
+thinking that the user is trying to select the module when in fact they only
+want to find out more about it. So this bit of code will stop the click before
+it reaches the main :code:`div` element and activating the above code::
+
+    $("div.module > div.group > a").click(function (event) {
+
+        event.cancelBubble = true;
+
+        if (event.stopPropagation) {
+            event.stopPropagation();
+        }
+    })
+    
+The :code:`cancelBubble = true` line is needed to support Internet Explorer
+browsers while the :code:`stopPropogation` function is for all the other browsers.
+
 -----------------------------
 Clearing all Selected Modules
 -----------------------------

--- a/js/main.js
+++ b/js/main.js
@@ -209,6 +209,18 @@ $(document).ready(function() {
             updateTotals(creditTotals);
         });
 
+    // This stops clicks on the more-info link also (de)selecting the module
+    $("div.module > div.group > a").click(function (event) {
+
+        // For IE
+        event.cancelBubble = true;
+
+        // For everyone else
+        if (event.stopPropagation) {
+            event.stopPropagation();
+        }
+    })
+
     // This sets up the clear button with its ability to deselect everything
     $("div.wrapper > h2.clear").click(function() {
         $("div.optional > div.module").each(function() {


### PR DESCRIPTION
This adds a few lines of extra Javascript to `main.js` to fix the bug
where a user would click on the `More Info` link on a module and end up
also (de)selecting the module which of course is not the desired action.

Also updated the docs to reflect these changes
